### PR TITLE
[Cases][Templates] Fix required-field error when applying/changing a template

### DIFF
--- a/x-pack/platform/plugins/shared/cases/public/components/case_view/use_change_applied_template.test.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/case_view/use_change_applied_template.test.ts
@@ -8,6 +8,7 @@
 import { renderHook, waitFor, act } from '@testing-library/react';
 import { TestProviders } from '../../common/mock';
 import { basicCase } from '../../containers/mock';
+import type { Field } from '../../../common/types/domain/template/fields';
 import { computeNewExtendedFields, useChangeAppliedTemplate } from './use_change_applied_template';
 
 const mockPatchCase = jest.fn();
@@ -100,6 +101,38 @@ describe('computeNewExtendedFields', () => {
 
   it('returns an empty object when the new template has no fields', () => {
     const result = computeNewExtendedFields([], { priorityAsKeyword: 'high' });
+
+    expect(result).toEqual({});
+  });
+
+  it('omits fields that resolve to an empty value instead of writing "" (required-field regression)', () => {
+    // A required field with no default and no existing value must NOT be sent as '' — that trips
+    // the server's partial-update "Field X is required" validation on template apply/change.
+    const fields: Field[] = [
+      { name: 'required_no_default', type: 'keyword', control: 'INPUT_TEXT' },
+      { name: 'empty_default', type: 'keyword', control: 'INPUT_TEXT', metadata: { default: '' } },
+    ];
+
+    const result = computeNewExtendedFields(fields, {});
+
+    expect(result).not.toHaveProperty('required_no_default_as_keyword');
+    expect(result).not.toHaveProperty('empty_default_as_keyword');
+  });
+
+  it('omits empty-array defaults ("[]") which also count as empty for required validation', () => {
+    const fields: Field[] = [
+      { name: 'labels', type: 'keyword', control: 'CHECKBOX_GROUP', metadata: { default: [] } },
+    ];
+
+    const result = computeNewExtendedFields(fields, {});
+
+    expect(result).not.toHaveProperty('labels_as_keyword');
+  });
+
+  it('skips $ref fields (no inline definition to derive a value from)', () => {
+    const fields: Field[] = [{ $ref: 'library_field' }];
+
+    const result = computeNewExtendedFields(fields, {});
 
     expect(result).toEqual({});
   });

--- a/x-pack/platform/plugins/shared/cases/public/components/case_view/use_change_applied_template.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/case_view/use_change_applied_template.ts
@@ -61,10 +61,16 @@ export const computeNewExtendedFields = (
       const snakeKey = getFieldSnakeKey(field.name, field.type);
       const camelKey = getFieldCamelKey(field.name, field.type);
       const existingValue = currentExtendedFields[camelKey];
-      if (existingValue !== undefined && existingValue !== '') {
-        result[snakeKey] = String(existingValue);
-      } else {
-        result[snakeKey] = getYamlDefaultAsString(field.metadata?.default);
+      const value =
+        existingValue !== undefined && existingValue !== ''
+          ? String(existingValue)
+          : getYamlDefaultAsString(field.metadata?.default);
+      // Omit empty values instead of writing '' / '[]'. A present-but-empty key trips the server's
+      // partial-update validation for required fields (the "Field X is required" error seen when
+      // applying or changing a template); omitting it lets the update treat the field as untouched,
+      // and the user fills it on the case afterwards.
+      if (value !== '' && value !== '[]') {
+        result[snakeKey] = value;
       }
     }
   }


### PR DESCRIPTION
## Summary

Stacked on #277626. This fixes a sharp edge where applying or changing a template on an existing case would fail with a validation error and leave the case looking broken (no fields shown).

## Why

When you applied a template — or switched templates — on a case, you could get:

> Invalid extended_fields: Field "Compromised account (UPN or username)" is required

And after the error, the case rendered no custom fields, so it looked like the apply had wiped everything. Retrying just repeated the error. This also happened when applying the *first* template to a case that was created with none — so it wasn't only a "change template" problem.

## Root cause

`computeNewExtendedFields` was writing an empty string (`''`) for every inline template field that had no carried-over value and no default. On a case update we validate `extended_fields` in **partial** mode, and a *present-but-empty* key for a required field fails the required check. So the field the user never touched was rejected as "required," the PATCH failed, and (since the apply never actually landed) the case showed nothing.

## What changed

- `computeNewExtendedFields` now **omits** empty values (`''` and `'[]`') instead of writing them. Fields with a real default or a carried-over value are still written; untouched required fields are simply left out, so partial validation treats them as unchanged and the user fills them in on the case.
- `'[]'` (empty array control) is treated as empty too, since the server counts it as empty for required validation.

## Behavior changes

- Applying/changing a template no longer throws a spurious "Field X is required" error for fields you haven't filled in.
- The apply actually lands, so fields render correctly afterward.

## Test plan

- `node scripts/jest x-pack/platform/plugins/shared/cases/public/components/case_view/use_change_applied_template.test.ts`
- Added cases for: omitting empty/no-default fields, omitting empty-array defaults, and skipping `$ref` fields.
- Manual: with the testing-party templates, apply a template with a required field to a no-template case and switch between templates — no error, fields populate.

Made with [Cursor](https://cursor.com)